### PR TITLE
pin nodejs major version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,5 @@
 {% set version = "1.3.0" %}
+{% set node_version = os.environ.get('NODEJS_VERSION') or '4.*' %}
 
 package:
   name: configurable-http-proxy
@@ -10,14 +11,14 @@ source:
   sha256: 4c59c33a0db7b353d626691bd70763cdb7c5a97850cb3f0f01eb7111867fd9e3
 
 build:
-  number: 0
+  number: 1
   script: npm install -g .
 
 requirements:
   build:
-    - nodejs
+    - nodejs {{node_version}}
   run:
-    - nodejs
+    - nodejs {{node_version}}
 
 test:
   commands:


### PR DESCRIPTION
avoids automatic updating of nodejs underneath, which might not be compatible
