### PR TITLE
Rebuild for nodejs 14,16,17

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,40 +8,40 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_nodejs12:
-        CONFIG: linux_64_nodejs12
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-cos7-x86_64
       linux_64_nodejs14:
         CONFIG: linux_64_nodejs14
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: condaforge/linux-anvil-cos7-x86_64
-      linux_64_nodejs15:
-        CONFIG: linux_64_nodejs15
+      linux_64_nodejs16:
+        CONFIG: linux_64_nodejs16
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: condaforge/linux-anvil-cos7-x86_64
-      linux_aarch64_nodejs12:
-        CONFIG: linux_aarch64_nodejs12
+      linux_64_nodejs17:
+        CONFIG: linux_64_nodejs17
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: condaforge/linux-anvil-cos7-x86_64
       linux_aarch64_nodejs14:
         CONFIG: linux_aarch64_nodejs14
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_aarch64_nodejs15:
-        CONFIG: linux_aarch64_nodejs15
+      linux_aarch64_nodejs16:
+        CONFIG: linux_aarch64_nodejs16
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_ppc64le_nodejs12:
-        CONFIG: linux_ppc64le_nodejs12
+      linux_aarch64_nodejs17:
+        CONFIG: linux_aarch64_nodejs17
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_ppc64le_nodejs14:
         CONFIG: linux_ppc64le_nodejs14
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_ppc64le_nodejs15:
-        CONFIG: linux_ppc64le_nodejs15
+      linux_ppc64le_nodejs16:
+        CONFIG: linux_ppc64le_nodejs16
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_ppc64le_nodejs17:
+        CONFIG: linux_ppc64le_nodejs17
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
   timeoutInMinutes: 360

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,14 +8,14 @@ jobs:
     vmImage: macOS-10.15
   strategy:
     matrix:
-      osx_64_nodejs12:
-        CONFIG: osx_64_nodejs12
-        UPLOAD_PACKAGES: 'True'
       osx_64_nodejs14:
         CONFIG: osx_64_nodejs14
         UPLOAD_PACKAGES: 'True'
-      osx_64_nodejs15:
-        CONFIG: osx_64_nodejs15
+      osx_64_nodejs16:
+        CONFIG: osx_64_nodejs16
+        UPLOAD_PACKAGES: 'True'
+      osx_64_nodejs17:
+        CONFIG: osx_64_nodejs17
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
 

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -8,14 +8,14 @@ jobs:
     vmImage: windows-2019
   strategy:
     matrix:
-      win_64_nodejs12:
-        CONFIG: win_64_nodejs12
-        UPLOAD_PACKAGES: 'True'
       win_64_nodejs14:
         CONFIG: win_64_nodejs14
         UPLOAD_PACKAGES: 'True'
-      win_64_nodejs15:
-        CONFIG: win_64_nodejs15
+      win_64_nodejs16:
+        CONFIG: win_64_nodejs16
+        UPLOAD_PACKAGES: 'True'
+      win_64_nodejs17:
+        CONFIG: win_64_nodejs17
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables:

--- a/.ci_support/linux_64_nodejs16.yaml
+++ b/.ci_support/linux_64_nodejs16.yaml
@@ -1,8 +1,12 @@
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+docker_image:
+- condaforge/linux-anvil-cos7-x86_64
 nodejs:
-- '15'
+- '16'
 target_platform:
-- win-64
+- linux-64

--- a/.ci_support/linux_64_nodejs17.yaml
+++ b/.ci_support/linux_64_nodejs17.yaml
@@ -7,6 +7,6 @@ channel_targets:
 docker_image:
 - condaforge/linux-anvil-cos7-x86_64
 nodejs:
-- '15'
+- '17'
 target_platform:
 - linux-64

--- a/.ci_support/linux_aarch64_nodejs16.yaml
+++ b/.ci_support/linux_aarch64_nodejs16.yaml
@@ -1,3 +1,7 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+cdt_arch:
+- aarch64
 cdt_name:
 - cos7
 channel_sources:
@@ -7,6 +11,6 @@ channel_targets:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 nodejs:
-- '12'
+- '16'
 target_platform:
-- linux-ppc64le
+- linux-aarch64

--- a/.ci_support/linux_aarch64_nodejs17.yaml
+++ b/.ci_support/linux_aarch64_nodejs17.yaml
@@ -11,6 +11,6 @@ channel_targets:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 nodejs:
-- '12'
+- '17'
 target_platform:
 - linux-aarch64

--- a/.ci_support/linux_ppc64le_nodejs16.yaml
+++ b/.ci_support/linux_ppc64le_nodejs16.yaml
@@ -7,6 +7,6 @@ channel_targets:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 nodejs:
-- '15'
+- '16'
 target_platform:
 - linux-ppc64le

--- a/.ci_support/linux_ppc64le_nodejs17.yaml
+++ b/.ci_support/linux_ppc64le_nodejs17.yaml
@@ -1,7 +1,3 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
-cdt_arch:
-- aarch64
 cdt_name:
 - cos7
 channel_sources:
@@ -11,6 +7,6 @@ channel_targets:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 nodejs:
-- '15'
+- '17'
 target_platform:
-- linux-aarch64
+- linux-ppc64le

--- a/.ci_support/osx_64_nodejs16.yaml
+++ b/.ci_support/osx_64_nodejs16.yaml
@@ -7,6 +7,6 @@ channel_targets:
 macos_machine:
 - x86_64-apple-darwin13.4.0
 nodejs:
-- '12'
+- '16'
 target_platform:
 - osx-64

--- a/.ci_support/osx_64_nodejs17.yaml
+++ b/.ci_support/osx_64_nodejs17.yaml
@@ -7,6 +7,6 @@ channel_targets:
 macos_machine:
 - x86_64-apple-darwin13.4.0
 nodejs:
-- '15'
+- '17'
 target_platform:
 - osx-64

--- a/.ci_support/win_64_nodejs16.yaml
+++ b/.ci_support/win_64_nodejs16.yaml
@@ -1,12 +1,8 @@
-cdt_name:
-- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-docker_image:
-- condaforge/linux-anvil-cos7-x86_64
 nodejs:
-- '12'
+- '16'
 target_platform:
-- linux-64
+- win-64

--- a/.ci_support/win_64_nodejs17.yaml
+++ b/.ci_support/win_64_nodejs17.yaml
@@ -3,6 +3,6 @@ channel_sources:
 channel_targets:
 - conda-forge main
 nodejs:
-- '12'
+- '17'
 target_platform:
 - win-64

--- a/README.md
+++ b/README.md
@@ -27,13 +27,6 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_nodejs12</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4648&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/configurable-http-proxy-feedstock?branchName=master&jobName=linux&configuration=linux_64_nodejs12" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
               <td>linux_64_nodejs14</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4648&branchName=master">
@@ -41,17 +34,17 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_nodejs15</td>
+              <td>linux_64_nodejs16</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4648&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/configurable-http-proxy-feedstock?branchName=master&jobName=linux&configuration=linux_64_nodejs15" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/configurable-http-proxy-feedstock?branchName=master&jobName=linux&configuration=linux_64_nodejs16" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_nodejs12</td>
+              <td>linux_64_nodejs17</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4648&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/configurable-http-proxy-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_nodejs12" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/configurable-http-proxy-feedstock?branchName=master&jobName=linux&configuration=linux_64_nodejs17" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -62,17 +55,17 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_nodejs15</td>
+              <td>linux_aarch64_nodejs16</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4648&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/configurable-http-proxy-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_nodejs15" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/configurable-http-proxy-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_nodejs16" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_nodejs12</td>
+              <td>linux_aarch64_nodejs17</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4648&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/configurable-http-proxy-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_nodejs12" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/configurable-http-proxy-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_nodejs17" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -83,17 +76,17 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_nodejs15</td>
+              <td>linux_ppc64le_nodejs16</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4648&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/configurable-http-proxy-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_nodejs15" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/configurable-http-proxy-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_nodejs16" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_nodejs12</td>
+              <td>linux_ppc64le_nodejs17</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4648&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/configurable-http-proxy-feedstock?branchName=master&jobName=osx&configuration=osx_64_nodejs12" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/configurable-http-proxy-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_nodejs17" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -104,17 +97,17 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_nodejs15</td>
+              <td>osx_64_nodejs16</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4648&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/configurable-http-proxy-feedstock?branchName=master&jobName=osx&configuration=osx_64_nodejs15" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/configurable-http-proxy-feedstock?branchName=master&jobName=osx&configuration=osx_64_nodejs16" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_nodejs12</td>
+              <td>osx_64_nodejs17</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4648&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/configurable-http-proxy-feedstock?branchName=master&jobName=win&configuration=win_64_nodejs12" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/configurable-http-proxy-feedstock?branchName=master&jobName=osx&configuration=osx_64_nodejs17" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -125,10 +118,17 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_nodejs15</td>
+              <td>win_64_nodejs16</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4648&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/configurable-http-proxy-feedstock?branchName=master&jobName=win&configuration=win_64_nodejs15" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/configurable-http-proxy-feedstock?branchName=master&jobName=win&configuration=win_64_nodejs16" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_nodejs17</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4648&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/configurable-http-proxy-feedstock?branchName=master&jobName=win&configuration=win_64_nodejs17" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -8,6 +8,6 @@ cdt_name:                                 # [linux64]
   - cos7                                  # [linux64]
 
 nodejs:
-  - 15
+  - 17
+  - 16
   - 14
-  - 12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "configurable-http-proxy" %}
 {% set version = "4.5.1" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 {% if not nodejs %}
 # rerender doesn't always pull node value from conda_build_config on first pass


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
*  Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Thanks to some gitter help, I think a required change was missed with #44 and thus got reverted with the rerender done in #45.  That being `nodejs` was not built on versions 14, 15, and 17.